### PR TITLE
added meta description to describe content

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,7 @@
     />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta name="theme-color" content="#000000" />
+    <meta name="description" content="Se hvilke personopplysninger NAV har lagret om deg. Du kan endre personalia og oppdatere din informasjon via denne siden."/>
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
     <link rel="stylesheet" href="%PUBLIC_URL%/index.css" />


### PR DESCRIPTION
Added `meta description` tag and a summary proposal to describe content of Personopplysninger.

The meta description tag is a short summary about a webpage used in search engine results. Using this tag helps users understand what the page is about and helps search engines understand the purpose of a page. Without a meta tag the search engines will attempt to describe the page on their own.