### PR TITLE
Forbedre validering av norsk kontonummer

### DIFF
--- a/src/pages/forside/sections/4-personinfo/2-kontaktinfo/subsections/TelefonnummerHosNav.tsx
+++ b/src/pages/forside/sections/4-personinfo/2-kontaktinfo/subsections/TelefonnummerHosNav.tsx
@@ -35,13 +35,6 @@ const TelefonnummerHosNav = (props: Props) => {
           <AlertStripeAdvarsel>{driftsmeldinger.pdl}</AlertStripeAdvarsel>
         </div>
       )}
-      <div style={{ paddingBottom: "1rem" }}>
-        <AlertStripeAdvarsel>
-          Endring og sletting av telefonnummer kan gå litt tregere enn vanlig.
-          Endringene går igjennom, men det kan ta litt tid før de blir synlige
-          på denne siden.
-        </AlertStripeAdvarsel>
-      </div>
       <div className="underseksjon__header">
         <Undertittel>
           <FormattedMessage id="personalia.tlfnr.oveskrift" />

--- a/src/pages/forside/sections/4-personinfo/4-utbetalinger/Utbetalinger.tsx
+++ b/src/pages/forside/sections/4-personinfo/4-utbetalinger/Utbetalinger.tsx
@@ -7,12 +7,14 @@ import endreIkon from "assets/img/Pencil.svg";
 import leggTilIkon from "assets/img/Pencil.svg";
 import NorskKontonummer from "./visning/NorskKontonummer";
 import Utenlandskonto from "./visning/UtenlandsBankkonto";
-import OpprettEllerEndreNorskKontonr from "./endring/NorskKontonummer";
-import { setOutboundNorskKontonummer } from "./endring/NorskKontonummer";
-import { OutboundNorskKontonummer } from "./endring/NorskKontonummer";
-import OpprettEllerEndreUtenlandsbank from "./endring/utenlandsk-bankkonto/UtenlandsBankkonto";
-import { setOutboundUtenlandsbankonto } from "./endring/utenlandsk-bankkonto/UtenlandsBankkonto";
-import { OutboundUtenlandsbankonto } from "./endring/utenlandsk-bankkonto/UtenlandsBankkonto";
+import OpprettEllerEndreNorskKontonr, {
+  OutboundNorskKontonummer,
+  setOutboundNorskKontonummer,
+} from "./endring/NorskKontonummer";
+import OpprettEllerEndreUtenlandsbank, {
+  OutboundUtenlandsbankonto,
+  setOutboundUtenlandsbankonto,
+} from "./endring/utenlandsk-bankkonto/UtenlandsBankkonto";
 import { Radio, RadioGruppe } from "nav-frontend-skjema";
 import { FormattedMessage, useIntl } from "react-intl";
 import { Knapp } from "nav-frontend-knapper";
@@ -23,6 +25,7 @@ import { PersonInfo } from "types/personInfo";
 import { useStore } from "store/Context";
 import driftsmeldinger from "driftsmeldinger";
 import { AlertStripeAdvarsel } from "nav-frontend-alertstriper";
+import { normalizeNummer } from "../../../../../utils/formattering";
 
 interface Props {
   utenlandskbank?: UtenlandskBankkonto;
@@ -60,7 +63,10 @@ const Utbetalinger = (props: Props) => {
     if (isValid) {
       type Outbound = OutboundNorskKontonummer | OutboundUtenlandsbankonto;
       const outbound: { [key: string]: () => Outbound } = {
-        NORSK: () => setOutboundNorskKontonummer(context),
+        NORSK: () => {
+          fields.kontonummer = normalizeNummer(fields.kontonummer);
+          return setOutboundNorskKontonummer(context);
+        },
         UTENLANDSK: () => setOutboundUtenlandsbankonto(context),
       };
 
@@ -86,7 +92,12 @@ const Utbetalinger = (props: Props) => {
   };
 
   return (
-    <Box id="utbetaling" tittel="utbetalinger.tittel" icon={kontonummerIkon} visAnkerlenke={true}>
+    <Box
+      id="utbetaling"
+      tittel="utbetalinger.tittel"
+      icon={kontonummerIkon}
+      visAnkerlenke={true}
+    >
       <>
         {driftsmeldinger.pdl && (
           <div style={{ paddingBottom: "1rem" }}>

--- a/src/pages/forside/sections/4-personinfo/4-utbetalinger/endring/NorskKontonummer.tsx
+++ b/src/pages/forside/sections/4-personinfo/4-utbetalinger/endring/NorskKontonummer.tsx
@@ -31,8 +31,7 @@ const OpprettEllerEndreNorskKontonr = (props: Props) => {
   const formConfig = {
     kontonummer: {
       isRequired: msg({ id: "validation.kontonummer.pakrevd" }),
-      isNumber: msg({ id: "validation.kontonummer.siffer" }),
-      isExactLength: {
+      isNormalizedLength: {
         message: msg({ id: "validation.kontonummer.elleve" }),
         length: 11,
       },
@@ -57,9 +56,7 @@ const OpprettEllerEndreNorskKontonr = (props: Props) => {
               maxLength={16}
               value={fields.kontonummer}
               label={msg({ id: "felter.kontonummer.label" })}
-              onChange={(e) =>
-                setField({ kontonummer: e.target.value.replace(/\D/g, "") })
-              }
+              onChange={(e) => setField({ kontonummer: e.target.value })}
               feil={submitted && errors.kontonummer}
             />
           </div>

--- a/src/pages/forside/sections/4-personinfo/4-utbetalinger/endring/NorskKontonummer.tsx
+++ b/src/pages/forside/sections/4-personinfo/4-utbetalinger/endring/NorskKontonummer.tsx
@@ -54,10 +54,12 @@ const OpprettEllerEndreNorskKontonr = (props: Props) => {
           <div className="utbetalinger__input input--m">
             <Input
               bredde={"M"}
-              maxLength={11}
+              maxLength={16}
               value={fields.kontonummer}
               label={msg({ id: "felter.kontonummer.label" })}
-              onChange={(e) => setField({ kontonummer: e.target.value })}
+              onChange={(e) =>
+                setField({ kontonummer: e.target.value.replace(/\D/g, "") })
+              }
               feil={submitted && errors.kontonummer}
             />
           </div>

--- a/src/pages/forside/sections/4-personinfo/4-utbetalinger/endring/utils.ts
+++ b/src/pages/forside/sections/4-personinfo/4-utbetalinger/endring/utils.ts
@@ -1,8 +1,8 @@
 import { OptionType } from "types/option";
 import { Fields } from "calidation";
 import {
-  LAND_MED_BANKKODE,
   BIC,
+  LAND_MED_BANKKODE,
 } from "./utenlandsk-bankkonto/UtenlandsBankkonto";
 
 import { LandOppslag } from "./landOppslag";


### PR DESCRIPTION
Øker maxLength på kontonummer-felt og stripper bort ikke-numeriske tegn for å tillate copy-pasting av kontonumre med feks punktum og whitespace