### PR TITLE
Prefiks postboksadresse med "Postboks" i visning

### DIFF
--- a/src/pages/forside/sections/4-personinfo/3-adresser/visning/adressetyper/norske-adresser/Postboksadresse.tsx
+++ b/src/pages/forside/sections/4-personinfo/3-adresser/visning/adressetyper/norske-adresser/Postboksadresse.tsx
@@ -2,6 +2,9 @@ import { BodyShort } from '@navikt/ds-react';
 import Postnummer from '../../../komponenter/Postnummer';
 import { Postboksadresse as PostboksadresseType } from '@/types/adresser/adresse';
 
+const formatPostboks = (postboks: string) =>
+    /^postboks\b/i.test(postboks.trim()) ? postboks : `Postboks ${postboks}`;
+
 const Postboksadresse = (props: PostboksadresseType) => {
     const { postbokseier, postboks, postnummer, coAdressenavn } = props;
     const { poststed } = props;
@@ -19,7 +22,7 @@ const Postboksadresse = (props: PostboksadresseType) => {
             )}
             {postboks && (
                 <div className="adresse__linje">
-                    <BodyShort>{postboks}</BodyShort>
+                    <BodyShort>{formatPostboks(postboks)}</BodyShort>
                 </div>
             )}
             <Postnummer postnummer={postnummer} poststed={poststed} />


### PR DESCRIPTION
## Sammendrag
- Postboksadresser kommuniseres nå tydelig som postboks ved at `postboks`-feltet prefikses med "Postboks" i visningen, dersom verdien ikke allerede begynner med det (case-insensitivt).
- Endringen ligger i `Postboksadresse.tsx`, som dekker alle norske POSTBOKSADRESSE-er (bostedsadresse, oppholdsadresse og kontaktadresse via felles `Adresse.tsx`-switch).

## Test plan
- [ ] Verifiser at en postboksadresse hvor API returnerer f.eks. `"10 Sørstrand"` vises som `Postboks 10 Sørstrand`.
- [ ] Verifiser at en postboksadresse hvor API allerede returnerer `"Postboks 10 Sørstrand"` vises uendret (ingen dobbel "Postboks").
- [ ] Verifiser at vanlige vegadresser fortsatt vises som før.